### PR TITLE
Add rawkicad footprint

### DIFF
--- a/src/footprints/index.js
+++ b/src/footprints/index.js
@@ -11,6 +11,7 @@ module.exports = {
     omron: require('./omron'),
     pad: require('./pad'),
     promicro: require('./promicro'),
+    rawkicad: require('./rawkicad'),
     rgb: require('./rgb'),
     rotary: require('./rotary'),
     scrollwheel: require('./scrollwheel'),

--- a/src/footprints/rawkicad.js
+++ b/src/footprints/rawkicad.js
@@ -1,0 +1,7 @@
+module.exports = {
+    params: {
+        class: 'RAW',
+        data: ''
+    },
+    body: p => p.param.data
+}


### PR DESCRIPTION
Add a `rawkicad` footprint to add tracks / groundfill etc. in the ergogen config